### PR TITLE
updates deprecated function in timer.background()

### DIFF
--- a/timers.ts
+++ b/timers.ts
@@ -21,7 +21,7 @@ namespace timer {
     //% block="separately do"
     //% handlerStatement=1
     export function background(then: () => void) {
-        control.runInBackground(then)
+        control.runInParallel(then)
     }
 
     let decounceTimeouts: {[key: string]: number} = {}


### PR DESCRIPTION
`runInBackground()` is deprecated. Swapped it out for `runInParallel()`. No user-facing changes.