### PR TITLE
Adds ability to cancel events

### DIFF
--- a/timers.ts
+++ b/timers.ts
@@ -9,7 +9,19 @@ namespace timer {
     //% time.defl=500
     //% handlerStatement=1
     //% %time=timePicker ms"
-    export function after(time: number, thenDo: () => void): number {
+    export function after(time: number, thenDo: () => void) {
+        setTimeout(thenDo, time)
+    }
+
+    /**
+ * Same functionality as the after block, however this returns
+ * an ID which can be cancelled using the cancel block.
+ */
+    //% block="after $time do"
+    //% time.defl=500
+    //% handlerStatement=1
+    //% %time=timePicker ms"
+    export function afterID(time: number, thenDo: () => void): number {
         let id: number = setTimeout(thenDo, time)
         return id
     }

--- a/timers.ts
+++ b/timers.ts
@@ -9,10 +9,21 @@ namespace timer {
     //% time.defl=500
     //% handlerStatement=1
     //% %time=timePicker ms"
-    export function after(time: number, thenDo: () => void) {
-        setTimeout(thenDo, time)
+    export function after(time: number, thenDo: () => void): number {
+        let id: number = setTimeout(thenDo, time)
+        return id
     }
 
+    /**
+     * Cancels the code scheduled to run in the after block (referenced by
+     * the blocks id).
+     */
+    //% block="cancel function: $id"
+    export function cancel(id: number)
+    {
+        clearTimeout(id)
+    }
+    
     /**
      * Run the attached code seperately from other code.
      * This creates a seperate context for "pause" so that pauses


### PR DESCRIPTION
This PR adds 2 new blocks:

- afterID, which is a direct copy of the after block but returns the id of the scheduled event.

- cancel, which takes in the id of the event and cancels it.

These two functions can be used in conjunction with each other for various purposes.